### PR TITLE
SLURM can be called Slurm now

### DIFF
--- a/docs/applications/basic-commands.md
+++ b/docs/applications/basic-commands.md
@@ -119,7 +119,7 @@ The ```sbatch``` arguments here are the minimal subset required to accurately sp
 		</tr>
 		<tr>
 			<td>--account</td>
-			<td>Charge resources used by this job to specified account. This is only relevant for users who are in multiple SLURM accounts because he/she is in groups that are collaborating.</td>
+			<td>Charge resources used by this job to specified account. This is only relevant for users who are in multiple Slurm accounts because he/she is in groups that are collaborating.</td>
 		</tr>
 	</tbody>
 </table>

--- a/docs/applications/crc-wrappers.md
+++ b/docs/applications/crc-wrappers.md
@@ -1,6 +1,6 @@
 # CRC Wrappers
 
-The CRC Team provides some wrapper scripts that make interacting with SLURM easier by abstracting away some of the details of common commands. The scripts are written in Python and should accept;<span style="font-family:courier new,courier,monospace;">-h</span>;and;<span style="font-family:courier new,courier,monospace;">--help</span>;to provide help documentation.
+The CRC Team provides some wrapper scripts that make interacting with Slurm easier by abstracting away some of the details of common commands. The scripts are written in Python and should accept;<span style="font-family:courier new,courier,monospace;">-h</span>;and;<span style="font-family:courier new,courier,monospace;">--help</span>;to provide help documentation.
 
 ## What commands are available?
 
@@ -10,7 +10,7 @@ The CRC Team provides some wrapper scripts that make interacting with SLURM easi
 	<thead>
 		<tr>
 			<td>Wrapper Command</td>
-			<td>SLURM Functionality</td>
+			<td>Slurm Functionality</td>
 			<td>Explanation</td>
 		</tr>
 	</thead>

--- a/docs/applications/licensed-software/lumerical.md
+++ b/docs/applications/licensed-software/lumerical.md
@@ -99,12 +99,12 @@ To end your MATE session, click on **System** followed by **Shut Down** or **Log
 
 ![](https://crc.pitt.edu/sites/default/files/viz-lumerical-09.png)
 
-## 3. Submitting a SLURM batch job to CRC cluster
+## 3. Submitting a Slurm batch job to CRC cluster
 
 There is a limited number of GUI licenses (3x) but a larger number of compute engine licenses (12x). One strategy to 
 optimize usage of the GUI licenses is to use the Lumerical IDE to set up the simulation system, close the IDE 
 (to free up the license), and then submit jobs to the CRC cluster. You will need a FDTD project file (`.fsp`) and a 
-SLURM job submission script. An example can be found within the following directory on the cluster login node
+Slurm job submission script. An example can be found within the following directory on the cluster login node
 
 ```commandline
 /ihome/crc/how_to_run/lumerical

--- a/docs/applications/licensed-software/matlab/matlab-remote-job-submission.md
+++ b/docs/applications/licensed-software/matlab/matlab-remote-job-submission.md
@@ -5,7 +5,7 @@ toolbox to allow you to submit jobs from directly to a remote HPC cluster.
 
 This allows you to take full advantage of the computing power available on the CRC's clusters to perform complex 
 parallelized computations in MATLAB. Parallel jobs can be submitted either from an SBATCH submission on the clusters 
-or on your own computer with custom a set of custom scripts that integrate with SLURM. In fact, you must use the 
+or on your own computer with custom a set of custom scripts that integrate with Slurm. In fact, you must use the 
 MATLAB Parallel Server if you want to run MATLAB jobs that span multiple nodes. 
 
 When you submit a MATLAB Parallel Server job from your MATLAB desktop client, scripts and data are transferred to the 

--- a/docs/applications/python.md
+++ b/docs/applications/python.md
@@ -154,10 +154,10 @@ Using custom virtual environments with Jupyter on OnDemand:
     ![type:video](../_assets/img/applications/7.install_jupyterlmod.mp4)
     ![type:video](../_assets/img/applications/jupyter_ondemand.mp4)
 
-Running SLURM jobs using your virtual environment:
+Running Slurm jobs using your virtual environment:
 --------------------------------------------------
 
-Here are sample batch files for creating a SLURM job using your newly installed virtual environment depending on the way you created the environment:
+Here are sample batch files for creating a Slurm job using your newly installed virtual environment depending on the way you created the environment:
 
 1.  If you used an Lmod python module to create your environment, then you must follow the following format (the same python module you used for creating the environment must be used):
     

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,8 @@ This section provides articles on general policies that apply when using the clu
 | [![Jupyterhub](_assets/img/home/CRC_Jhub.png)](https://hub.crc.pitt.edu) | [![viz](_assets/img/home/CRC_VIZ.png)](https://viz.crc.pitt.edu/) | [![psych](_assets/img/home/CRC_Psych.png)](https://psych.crc.pitt.edu/) | [![ondemand](_assets/img/home/CRC_Ondemand.png)](https://ondemand.htc.crc.pitt.edu/) |
 | [Jupyterhub Documentation](web-portals/jupyter-hub.md)                   | [VIZ Documentation](web-portals/viz.md)                           | [Psych Documentation](web-portals/psych.md)                             | [OnDemand Documentation](web-portals/open-ondemand.md)                               |
     
-## The SLURM Workload Manager
-See these pages for instructions on how to interact with SLURM via batch and interactive jobs.
+## The Slurm Workload Manager
+See these pages for instructions on how to interact with Slurm via batch and interactive jobs.
 
 ## Data Management
 These pages detail our filesystem configuration as well as the various methods you can use to 
@@ -28,7 +28,7 @@ move and share files.
 
 ## Applications
 Search through our list of software we make available on the cluster via the module system, and find
-details about the various applications we've built to more easily extract information from SLURM.
+details about the various applications we've built to more easily extract information from Slurm.
 This section also includes more in-depth pages on setting up python environments and working with 
 licensed software.
 

--- a/docs/policies/hardware-investing-policy.md
+++ b/docs/policies/hardware-investing-policy.md
@@ -28,7 +28,7 @@ benefits stated below.
             <td>All hardware is professionally managed by the Network Operations Center (https://www.technology.pitt.edu/network-operations-center-noc) at no charge to investors, and are administered with state of the art networking and security practices.</td>
         </tr>
         <tr>
-            <td>SLURM Allocation Service Units</td>
+            <td>Slurm Allocation Service Units</td>
             <td>Investors receive a 5-year user investment allocation on CRC hardware, equivalent to 100% of the computational resources that they would have utilized had they purchased and housed hardware within their own group, enabling utilization of their investment in the context of the existing CRC infrastructure.</td>
         </tr>
         <tr>

--- a/docs/policies/job-scheduling-policy.md
+++ b/docs/policies/job-scheduling-policy.md
@@ -113,7 +113,7 @@ are available to other users within a reasonable time frame.
 ## Exceeding Usage Limits will cause Job Pending Status
 After submission, a job can appear with a "status" of "PD" (not running).
 
-There are various reasons that SLURM will put your job in a pending state. Some common explanations are listed below.
+There are various reasons that Slurm will put your job in a pending state. Some common explanations are listed below.
 
 ### Reasons related to resource availability and job dependencies:
 
@@ -139,7 +139,7 @@ There are various reasons that SLURM will put your job in a pending state. Some 
         <tr>
             <td>Dependency</td>
             <td>A job cannot start until another job is finished. This only happens if you included a &quot;--dependency&quot; 
-directive in your SLURM script.</td>
+directive in your Slurm script.</td>
             <td>Wait until the job that you have marked as a dependency is finished, then your job will run</td>
         </tr>
         <tr>

--- a/docs/slurm/batch-jobs.md
+++ b/docs/slurm/batch-jobs.md
@@ -1,10 +1,10 @@
-# SLURM Batch Jobs
-A brief introduction to SLURM batch jobs and a simple example job can be found in our  
+# Slurm Batch Jobs
+A brief introduction to Slurm batch jobs and a simple example job can be found in our  
 [Getting Started section](https://crc.pitt.edu/getting-started/running-jobs-slurm).
 
-This page will provide lower level details related to SLURM jobs, as well as a more complex example submission script.
+This page will provide lower level details related to Slurm jobs, as well as a more complex example submission script.
 
-## SLURM Batch Job Arguments
+## Slurm Batch Job Arguments
 
 Below are a subset of sbatch arguments that can be used to specify a job on the cluster. You do not need to include 
 them all. 
@@ -77,7 +77,7 @@ Please refer to the [slurm documentation on sbatch](https://slurm.schedmd.com/sb
         </tr>
         <tr>
             <td><code>--cpus-per-task</code></td>
-            <td>Advise the SLURM controller that ensuing job steps will require ncpus number of processors per task.</td>
+            <td>Advise the Slurm controller that ensuing job steps will require ncpus number of processors per task.</td>
             <td> Use this to facillitate multithreading.</td>
         </tr>
         <tr>
@@ -99,7 +99,7 @@ Please refer to the [slurm documentation on sbatch](https://slurm.schedmd.com/sb
 	
 
 
-## A More Complex SLURM Submission Script Example
+## A More Complex Slurm Submission Script Example
 
 Below is a more abstracted example that loads some modules from the module systems, copies inputs and outputs, etc.
 

--- a/docs/slurm/job-arrays.md
+++ b/docs/slurm/job-arrays.md
@@ -12,7 +12,7 @@ Job arrays offer a mechanism for submitting and managing collections of similar 
 
 Job arrays are only supported for batch jobs and the array index values are specified using the --array or -a option of the sbatch command. The option argument can be specific array index values, a range of index values, and an optional step size as shown in the examples below.
 
-Assume that one has a folder with 5 paired end Illumila data set. The file names are ```SRR098333_1.fastq```, ```SRR098333_2.fastq```, ```SRR098334_1.fastq```, ```SRR098334_2.fastq```, …, ```SRR098338_1.fastq```, ```SRR098338_2.fastq```. One would like to perform fastqc on all files. create a SLURM batch file ```fastqc.sbatch```:
+Assume that one has a folder with 5 paired end Illumila data set. The file names are ```SRR098333_1.fastq```, ```SRR098333_2.fastq```, ```SRR098334_1.fastq```, ```SRR098334_2.fastq```, …, ```SRR098338_1.fastq```, ```SRR098338_2.fastq```. One would like to perform fastqc on all files. create a Slurm batch file ```fastqc.sbatch```:
 
 ```commandline
 #!/bin/bash
@@ -171,7 +171,7 @@ Sbatch will wrap the specified command string in a simple "sh" shell script, and
 
 For example, lets say you want to run gzip on all fastq files within this directory. Create a shell script called ```run_gzip.sh```:
 
-loop over all fastq files in the directory, print the filename and submit the gzip jobs to SLURM
+loop over all fastq files in the directory, print the filename and submit the gzip jobs to Slurm
 
 ```commandline
 #!/bin/bash
@@ -181,7 +181,7 @@ for FILE in \*.fastq; do
     sleep 1 # pause to be kind to the scheduler
 done
 ```
-then run script, which will submit a SLURM job for every .fastq file in the directory and gzip it.
+then run script, which will submit a Slurm job for every .fastq file in the directory and gzip it.
 ```commandline
 ./run_gzip.sh
 ```

--- a/docs/slurm/pbs-slurm.md
+++ b/docs/slurm/pbs-slurm.md
@@ -1,6 +1,6 @@
-# PBS to SLURM Commands
+# PBS to Slurm Commands
 
-PBS Torque and SLURM scripts are two frameworks for specifying the resource requirements and settings for the job you want to run. Frank used PBS Torque for specifying the resource requirement. For the most part, there are equivalent settings in each script. The following table lists examples of equivalent options for PBS and SLURM job scripts.
+PBS Torque and Slurm scripts are two frameworks for specifying the resource requirements and settings for the job you want to run. Frank used PBS Torque for specifying the resource requirement. For the most part, there are equivalent settings in each script. The following table lists examples of equivalent options for PBS and Slurm job scripts.
 
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
 
@@ -67,4 +67,4 @@ PBS Torque and SLURM scripts are two frameworks for specifying the resource requ
     });
 </script>
 
-A complete comparison of PBS Torque and SLURM script commands&nbsp;is available.&nbsp; <strong>link to PDF</strong>
+A complete comparison of PBS Torque and Slurm script commands&nbsp;is available.&nbsp; <strong>link to PDF</strong>

--- a/docs/slurm/scavenger.md
+++ b/docs/slurm/scavenger.md
@@ -11,15 +11,15 @@ For example, users may have noticed that:
 
 - We no longer add new nodes to the scavenger partitions of other clusters when the hardware is retired.
 
-Our team has made these decisions in the context of a larger conversation around our Allocation Proposal process, and the SLURM workload manager configuration used on the clusters:
+Our team has made these decisions in the context of a larger conversation around our Allocation Proposal process, and the Slurm workload manager configuration used on the clusters:
 
 **There are abundant compute resources are available upon request**
 
 A "Standard Allocation" of 25,000 service units per year is available to all faculty accounts, and is usable on any cluster to benchmark workflows and prepare a larger request for resources. The proposal process is sufficient for nearly all use cases we've encountered previously, and gives us a way to document the changing demands of our diverse user base over time. We will be increasing the standard allocation amount as well to help reduce any inconvenience caused by removing scavenger.
 
-**It simplifies our SLURM configuration related to job priority**
+**It simplifies our Slurm configuration related to job priority**
 
-As they are configured, the scavenger partitions have been found to create situations where jobs charging an account's service units are **not** preempting scavenger jobs due to how their priority factor is established. There are other ways within SLURM to manage priority and avoid this, so our intention is to simplify the configuration and ultimately provide more transparency to our users about how priority is computed.
+As they are configured, the scavenger partitions have been found to create situations where jobs charging an account's service units are **not** preempting scavenger jobs due to how their priority factor is established. There are other ways within Slurm to manage priority and avoid this, so our intention is to simplify the configuration and ultimately provide more transparency to our users about how priority is computed.
 
 Scavenger Partition Overview
 ----------------------------

--- a/docs/slurm/slurm-overview.md
+++ b/docs/slurm/slurm-overview.md
@@ -1,4 +1,4 @@
-# SLURM Overview
+# Slurm Overview
 
 The CRC clusters use [Slurm](http://slurm.schedmd.com/) for batch job queuing. 
 The `sinfo` command provides an overview of the state of the nodes within the cluster.


### PR DESCRIPTION
As mentioned in the BOF at SC23, Slurm is OK with not being called SLURM anymore, so we will make the corresponding change in the user manual.