### PR TITLE
Correct short QOS time to 1 day

### DIFF
--- a/docs/policies/job-scheduling-policy.md
+++ b/docs/policies/job-scheduling-policy.md
@@ -46,7 +46,7 @@ The priority weight for QOS is 2000.
             <td><code>Short</code></td>
             <td>13</td>
             <td>1.00</td>
-            <td>3-00:00:00</td>
+            <td>1-00:00:00</td>
         </tr>
         <tr>
             <td><code>Normal</code></td>


### PR DESCRIPTION
This PR corrects the QOS value of `short` to 1 day. Based on my review, this change aligns with other manual sections and accurately reflects the intended standard.