### PR TITLE
Change instances of CRC not in a hostname to CRCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# CRC User Manual
+# CRCD User Manual
 
-Source code for the official CRC user manual.
+Source code for the official CRCD user manual.
 
 ## Quick Start
 

--- a/docs/acknowledge-crc.md
+++ b/docs/acknowledge-crc.md
@@ -1,6 +1,6 @@
-# Acknowledge CRC Resources and Assistance in your Papers
+# Acknowledge CRCD Resources and Assistance in your Papers
 
-Please acknowledge CRC support in your publications.  
+Please acknowledge CRCD support in your publications.  
 
 All research products (publications, conference proceedings, and presentations) resulting from an allocation of computing time or storage on HTC (HTC cluster) should include the following acknowledgement:
 
@@ -12,6 +12,6 @@ All research products (publications, conference proceedings, and presentations) 
 
 "This research was supported in part by the University of Pittsburgh Center for Research Computing​, RRID:SCR_022735, through the resources provided. Specifically, this work used the H2P cluster, which is supported by NSF award number OAC-2117681."
 
-You are free to also acknowledge or thank individual members of the CRC team.
+You are free to also acknowledge or thank individual members of the CRCD team.
 
 Please remember to also list any research products (publications, conference proceedings, and presentations) resulting from a CRC allocation of in any allocation or renewal proposal.

--- a/docs/applications/application-environment.md
+++ b/docs/applications/application-environment.md
@@ -1,6 +1,6 @@
 # Application Environment
 
-The CRC utilizes [LMOD](https://www.tacc.utexas.edu/research-development/tacc-projects/lmod) to provide optimized 
+The CRCD utilizes [LMOD](https://www.tacc.utexas.edu/research-development/tacc-projects/lmod) to provide optimized 
 builds of commonly used software.
 
 Applications are available to users through the LMOD modular environment commands.

--- a/docs/applications/python.md
+++ b/docs/applications/python.md
@@ -1,6 +1,6 @@
 # Python
 
-The CRC provides a variety of pre-installed Python versions that can be accessed immediately through Lmod. Users can select from the available Python versions or install a different version if their target pipeline has specific requirements. A full list of available Python versions through Lmod can be viewed using:
+The CRCD provides a variety of pre-installed Python versions that can be accessed immediately through Lmod. Users can select from the available Python versions or install a different version if their target pipeline has specific requirements. A full list of available Python versions through Lmod can be viewed using:
     
 ```
 module spider python

--- a/docs/applications/software-list.md
+++ b/docs/applications/software-list.md
@@ -1,4 +1,4 @@
-# CRC Software List
+# CRCD Software List
 
 CRC uses the [lmod](./application-environment.md) environment modules system to provision software to our users. To query whether a software is available, use:
 ```

--- a/docs/code-optimization.md
+++ b/docs/code-optimization.md
@@ -1,10 +1,10 @@
 # Supporting Code Optimization
 
-Pitt CRC faculty consultants offer support for optimizing users' code. 
+Pitt CRCD faculty consultants offer support for optimizing users' code. 
 However, the support may vary depending upon our available resources, and the 
 volume and degree of the support needed. We ask that in your proposal you describe 
 the level of support you will need, and an estimation of the duration of that 
 support to allow our consultants to plan the most effective use of resources. 
 
-Pitt CRC consultants may also direct you toward workshops or other teaching 
+Pitt CRCD consultants may also direct you toward workshops or other teaching 
 resources in addition to or instead of direct consultation. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # Frequently asked questions
 
-*In this section we list a series of common problems that CRC users may encounter, with possible solutions.*
+*In this section we list a series of common problems that CRCD users may encounter, with possible solutions.*
 
 **1. A connection attempt to the cluster is rejected with a "POSSIBLE DNS SPOOFING" warning message**
 
@@ -28,4 +28,4 @@ ssh-keygen -R remote_machine
 
 where remote\_machine is the name or IP address of the computer you are trying to connect to. This will get rid of the cached host key, create a new one, and update the known\_hosts file automatically.
 
-The same issue can also occur when connecting to a remote machine from one of the login nodes of the CRC cluster. Again, removing the offending key from the known\_hosts file on the cluster will solve the problem.
+The same issue can also occur when connecting to a remote machine from one of the login nodes of the CRCD cluster. Again, removing the offending key from the known\_hosts file on the cluster will solve the problem.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Welcome to the CRC User Manual
+# Welcome to the CRCD User Manual
 
 This section of the [University of Pittsburgh Center for Research Computing](https://crc.pitt.edu/)  
 website is dedicated to helping you better utilize our services.

--- a/docs/policies/hardware-investing-policy.md
+++ b/docs/policies/hardware-investing-policy.md
@@ -1,17 +1,17 @@
 # Hardware Investing Policy
 
-The Pitt CRC provides a computing hardware investment opportunity for 
+The Pitt CRCD provides a computing hardware investment opportunity for 
 research to further enable the work of the broader Pitt community and 
-their own research groups. We maintain a separate category of CRC 
+their own research groups. We maintain a separate category of CRCD 
 Faculty users who do this called "Investors".
 
 Rather than incurring the burden of purchasing, installing, and 
 maintaining their own hardware, researchers can allocate grant or 
-startup funds to the CRC for community hardware purchases and the 
+startup funds to the CRCD for community hardware purchases and the 
 benefits stated below.
 
 
-## Benefits of Investing in CRC Resources
+## Benefits of Investing in CRCD Resources
 
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
 
@@ -29,11 +29,11 @@ benefits stated below.
         </tr>
         <tr>
             <td>Slurm Allocation Service Units</td>
-            <td>Investors receive a 5-year user investment allocation on CRC hardware, equivalent to 100% of the computational resources that they would have utilized had they purchased and housed hardware within their own group, enabling utilization of their investment in the context of the existing CRC infrastructure.</td>
+            <td>Investors receive a 5-year user investment allocation on CRCD hardware, equivalent to 100% of the computational resources that they would have utilized had they purchased and housed hardware within their own group, enabling utilization of their investment in the context of the existing CRCD infrastructure.</td>
         </tr>
         <tr>
             <td>Bulk Volume Equipment Rates</td>
-            <td>Investors can take advantage of lower equipment prices negotiated by CRC based on the large volumes required for our cluster refreshes.</td>
+            <td>Investors can take advantage of lower equipment prices negotiated by CRCD based on the large volumes required for our cluster refreshes.</td>
         </tr>
         <tr>
             <td>Better Utilization and Energy Efficiency</td>

--- a/docs/policies/job-scheduling-policy.md
+++ b/docs/policies/job-scheduling-policy.md
@@ -11,7 +11,7 @@ from one of the clusters, or as a batch job submission.
 
 Resource-intensive processes found to be running on the login nodes may be killed at anytime.
 
-<ins>**The CRC team reserves the right to revoke cluster access of any user who repeatedly causes slowdowns on the login 
+<ins>**The CRCD team reserves the right to revoke cluster access of any user who repeatedly causes slowdowns on the login 
 nodes with processes that can otherwise be run on the compute nodes.**</ins>
 
 ![JOB-SCHEDULING-POLICY1](../_assets/img/policies/job_scheduling_policy_1.png)
@@ -105,7 +105,7 @@ You can use the `sprio` slurm utility to see the priority of your jobs
 ## Walltime Extensions will generally not be Granted
 It is up to the job submitter to determine the demands of their job through some benchmarking before submitting, 
 perform any necessary code optimization, and to then specify the memory, cpu, and time requirements 
-accordingly. This ensures that the job is queued with respect to FairShare, and that CRC resources utilized by a job 
+accordingly. This ensures that the job is queued with respect to FairShare, and that CRCD resources utilized by a job 
 are available to other users within a reasonable time frame.
 
 ## Exceeding Usage Limits will cause Job Pending Status

--- a/docs/policies/resource-descriptions-for-writing-proposals.md
+++ b/docs/policies/resource-descriptions-for-writing-proposals.md
@@ -2,13 +2,13 @@
 
 ## Useful Resource Information For Writing External Proposals
 The information below may be of use to you in drafting proposals or other documents calling for descriptions of 
-Pitt CRC computational resources available to researchers.
+Pitt CRCD computational resources available to researchers.
 
-## Brief Text Description of CRC Resources
+## Brief Text Description of CRCD Resources
 Access to computing hardware, software, and research consulting are provided through the Pitt Center for Research 
-Computing (Pitt CRC). 
+Computing and Data (Pitt CRCD). 
 
-The CRC provides state-of-the-art high performance computing (HPC) resources allocated for shared use for campus 
+The CRCD provides state-of-the-art high performance computing (HPC) resources allocated for shared use for campus 
 researchers.
 
 The clusters comprise 136 dual 24-core Intel Xeon Gold Ice Lake, 22 dual 32-core Intel Xeon Platinum Ice Lake, 58 dual 
@@ -21,7 +21,7 @@ of 512 GB to 1024 GB per node shared memory. The global storage is comprised of 
 
 The systems are housed at the enterprise-level Network Operations Center (NOC) and are administered jointly with 
 Pitt IT. Pitt IT maintains the critical environmental infrastructure (power, cooling, networking, and security) and 
-administers the cluster operating systems and storage backups. CRC interfaces directly with researchers and provides 
+administers the cluster operating systems and storage backups. CRCD interfaces directly with researchers and provides 
 software installation services, training workshops, and personalized consultation on improving software 
 design/performance and computational workflows.
 
@@ -32,7 +32,7 @@ housed at the enterprise-level Network Operations Center (NOC), administered joi
 Pitt IT maintains the critical environmental infrastructure (power, cooling, networking, and security) and administers 
 the cluster operating systems and storage backups.
 
-CRC interfaces directly with researchers and provides software installation services, training workshops, and 
+CRCD interfaces directly with researchers and provides software installation services, training workshops, and 
 personalized consultation on improving software design/performance and computational workflows. The road map for 
 research computing infrastructure is developed jointly by CRC and CSSD to meet the emerging needs of researchers at 
 the University.

--- a/docs/slurm/interactive-jobs.md
+++ b/docs/slurm/interactive-jobs.md
@@ -28,7 +28,7 @@ compute nodes.
 [fangping@n409 ~]$
 ```
 
-Interactive jobs draw service units from the slurm allocation that your CRC user is associated with.
+Interactive jobs draw service units from the slurm allocation that your CRCD user is associated with.
 
 !!! note
 

--- a/docs/slurm/service-units.md
+++ b/docs/slurm/service-units.md
@@ -1,6 +1,6 @@
 # Service Units
 
-One service unit (SU) is approximately equal to 1 core hour of computing. The charge is calculated based on factors that the&nbsp;slurm workload manager calls '<strong>T</strong>rackable <strong>RES</strong>ources' or TRES. The important TRES values for calculating CRC SUs are:
+One service unit (SU) is approximately equal to 1 core hour of computing. The charge is calculated based on factors that the&nbsp;slurm workload manager calls '<strong>T</strong>rackable <strong>RES</strong>ources' or TRES. The important TRES values for calculating CRCD SUs are:
 
 - Number of cores requested
 - RAM requested

--- a/docs/slurm/slurm-overview.md
+++ b/docs/slurm/slurm-overview.md
@@ -1,6 +1,6 @@
 # Slurm Overview
 
-The CRC clusters use [Slurm](http://slurm.schedmd.com/) for batch job queuing. 
+The CRCD clusters use [Slurm](http://slurm.schedmd.com/) for batch job queuing. 
 The `sinfo` command provides an overview of the state of the nodes within the cluster.
 
 ```commandline

--- a/docs/slurm/vscode.md
+++ b/docs/slurm/vscode.md
@@ -1,6 +1,6 @@
 # Interactive / Remote Computing with VS Code
 
-This tutorial outlines how to set up VS Code for interactive/remote development/debugging on Pitt CRC computing nodes.
+This tutorial outlines how to set up VS Code for interactive/remote development/debugging on Pitt CRCD computing nodes.
 
 ## Prerequisites
 

--- a/docs/snippets/jupyter-hub.md
+++ b/docs/snippets/jupyter-hub.md
@@ -8,7 +8,7 @@
 
 ## **Summary**
 
-In addition to Jupyter notebook sessions via Open OnDemand, CRC also hosts the functionality for the multi-user equivalent
+In addition to Jupyter notebook sessions via Open OnDemand, CRCD also hosts the functionality for the multi-user equivalent
 [Jupyter Hub](https://jupyter.org/hub).
 
 [**Log in to Jupyter Hub**](https://hub.crc.pitt.edu)

--- a/docs/snippets/jupyter-ondemand.md
+++ b/docs/snippets/jupyter-ondemand.md
@@ -1,5 +1,5 @@
 # Jupyter on Ondemand User Guide
-The CRC offers Jupyter on OnDemand services to help users run Python notebooks on the different CRC clusters. We are currently offering Jupyter on the following clusters: HTC and GPU. The Jupyter on OnDemand service is available to all users with a CRC account. The Jupyter on OnDemand service is available, among other different applications, through the CRC OnDemand web portal at: [ondemand.htc.crc.pitt.edu](http://ondemand.htc.crc.pitt.edu).
+The CRCD offers Jupyter on OnDemand services to help users run Python notebooks on the different CRCD clusters. We are currently offering Jupyter on the following clusters: HTC and GPU. The Jupyter on OnDemand service is available to all users with a CRCD account. The Jupyter on OnDemand service is available, among other different applications, through the CRC OnDemand web portal at: [ondemand.htc.crc.pitt.edu](http://ondemand.htc.crc.pitt.edu).
 
 When you visit the OnDemand web portal, you will be prompted to log in with your Pitt account:  
   

--- a/docs/snippets/psych.md
+++ b/docs/snippets/psych.md
@@ -2,17 +2,17 @@
 
 ## **Summary**
 
-The Psychiatry Web Portal is the gateway to CRC compute and storage resources for the Department of Psychiatry.
+The Psychiatry Web Portal is the gateway to CRCD compute and storage resources for the Department of Psychiatry.
 
 **[Log in to Psych](https://psych.crc.pitt.edu)**
 
-To access this portal, you need to have a [user account](https://crc.pitt.edu/getting-started#) within CRC and be a member of the \`psych\` group.
+To access this portal, you need to have a [user account](https://crc.pitt.edu/getting-started#) within CRCD and be a member of the \`psych\` group.
 
 The portal server is firewalled within PittNet and as such [you will need to be on VPN](https://crc.pitt.edu/user-support/resource-documentation/vpn-and-accessing-clusters) or be directly connected to PittNet via Ethernet.
 
-Once connected, you can run commands directly on the server and submit batch jobs to the CRC clusters.
+Once connected, you can run commands directly on the server and submit batch jobs to the CRCD clusters.
 
-All CRC software can be accessed using a terminal and our LMOD software provisioning system.
+All CRCD software can be accessed using a terminal and our LMOD software provisioning system.
 
 \[TOC Contents\]
 
@@ -34,7 +34,7 @@ Click the plus button to add a new connection.
 
 ![](../_assets/img/web-portals/FastXDesktop1.png)
 
-In the dropdown at the top, make sure \`ssh\` is selected. Enter **psych.crc.pitt.edu** as the Host, and **your CRC Username (Pitt ID, all lowercase)** as the User. Click OK to continue.
+In the dropdown at the top, make sure \`ssh\` is selected. Enter **psych.crc.pitt.edu** as the Host, and **your CRCD Username (Pitt ID, all lowercase)** as the User. Click OK to continue.
 
 ![](../_assets/img/web-portals/FastXDesktop2.png)
 

--- a/docs/snippets/terminal.md
+++ b/docs/snippets/terminal.md
@@ -1,7 +1,7 @@
 # SSH Connection using a terminal
 
 SSH ([**Secure Shell**](https://en.wikipedia.org/wiki/Secure_Shell)) is a network protocol that allows for secure access 
-to a computer over an unsecured network. This is the protocol for connecting to the CRC login nodes.
+to a computer over an unsecured network. This is the protocol for connecting to the CRCD login nodes.
 
 Clients running Windows can use [**MobaXterm**](https://mobaxterm.mobatek.net/) or [**PuTTY**](https://www.putty.org/) to 
 access a terminal emulator. Clients running MacOS can use the built-in Terminal app (in Applications/Utilities) or 
@@ -16,7 +16,7 @@ Here are the connection details:
 * **remote hostname:** h2p.crc.pitt.edu or htc.crc.pitt.edu
 * **authentication credentials:** Pitt username (all lowercase) and password
 
-The syntax to connect to the CRC login node from your terminal commandline is
+The syntax to connect to the CRCD login node from your terminal commandline is
 
 ```commandline
 ssh -X username@h2p.crc.pitt.edu
@@ -36,7 +36,7 @@ If you encounter success, this is what your MacOS client session will look like
 
 *   **terminal emulator** -- a software program that provides a text-based interface to the system, allowing users to type 
 commands into a shell prompt to run programs and to manage files without a graphical user interface (GUI)
-*   **Linux shell** -- a text-based user-interface that interprets user commands and scripts. CRC supports `bash` and `csh`, with
+*   **Linux shell** -- a text-based user-interface that interprets user commands and scripts. CRCD supports `bash` and `csh`, with
  `bash` being the default
 *   **Linux commandline** -- this is the shell prompt line where your cursor is highlighted and where you input commands to the
  remote host

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: CRC User Manual
+site_name: CRCD User Manual
 repo_url: https://github.com/pitt-crc/user-manual
 site_url: https://crc-pages.pitt.edu/user-manual/
 theme:
@@ -81,7 +81,7 @@ nav:
       - Open OnDemand Webportal: getting-started/open-ondemand.md
       - JupyterHub Webportal: getting-started/jupyter-hub.md
       - JupyterHub on Teach Cluster: getting-started/jupyter-teach.md
-    - Step 3- CRC Ecosystem:
+    - Step 3- CRCD Ecosystem:
       - getting-started/step3/index.md
       - Discovering Software: getting-started/step3/getting-started-step3-software.md
       - Requesting Resources: getting-started/step3/getting-started-step3-resources.md
@@ -115,7 +115,7 @@ nav:
     - slurm/scavenger.md
     - slurm/job-arrays.md
     - slurm/vscode.md
-  - Acknowledge CRC Resources and Assistance in Your Papers: acknowledge-crc.md
+  - Acknowledge CRCD Resources and Assistance in Your Papers: acknowledge-crc.md
   - Data Management:
     - data-management/data-management-overview.md
     - data-management/google-workspace.md


### PR DESCRIPTION
Used pycharm to do a find and replace on instances of CRC to CRCD. Did not touch any hostnames. This should be most if not all of the instances throughout the user manual. 