### PR TITLE
Explicitly mention prerequisite VPN connection on cluster access method docs

### DIFF
--- a/docs/snippets/jupyter-hub.md
+++ b/docs/snippets/jupyter-hub.md
@@ -15,6 +15,10 @@ In addition to Jupyter notebook sessions via Open OnDemand, CRCD also hosts the 
 
 ## **Accessing CRCD Jupyter Hub**
 
+As with any of the other methods for connecting to CRCD resources, you should start by ensuring you have a proper 
+connection to the [GlobalProtect VPN](https://services.pitt.edu/TDClient/33/Portal/KB/ArticleDet?ID=293). With this 
+connection established, you can proceed with the steps below.
+
 The **Server Options** dropdown gives you the option to create a Jupyter Hub instance on your local machine, on the SMP cluster 
 (1 core, 3 hours), or on the GPU cluster with GTX 1080 (1 GPU, 3 hours) or A100 (1 GPU, 3 hours).
 

--- a/docs/snippets/jupyter-ondemand.md
+++ b/docs/snippets/jupyter-ondemand.md
@@ -1,8 +1,14 @@
 # Jupyter on Ondemand User Guide
 
 The CRCD offers Jupyter on OnDemand services to help users run Python notebooks on the different CRCD clusters. 
-We are currently offering Jupyter on the following clusters: HTC and GPU. The Jupyter on OnDemand service is available to all users with a CRCD account. 
-The Jupyter on OnDemand service is available, among other different applications, through the CRCD OnDemand web portal at: [ondemand.htc.crc.pitt.edu](http://ondemand.htc.crc.pitt.edu).
+We are currently offering Jupyter on the following clusters: HTC and GPU. The Jupyter on OnDemand service is available 
+to all users with a CRCD account. 
+The Jupyter on OnDemand service is available, among other different applications, through the CRCD OnDemand web portal 
+at: [ondemand.htc.crc.pitt.edu](http://ondemand.htc.crc.pitt.edu).
+
+As with any of the other methods for connecting to CRCD resources, you should start by ensuring you have a proper 
+connection to the [GlobalProtect VPN](https://services.pitt.edu/TDClient/33/Portal/KB/ArticleDet?ID=293). With this 
+connection established, you can proceed with the steps below.
 
 When you visit the OnDemand web portal, you will be prompted to log in with your Pitt account:  
   

--- a/docs/snippets/jupyter-teach.md
+++ b/docs/snippets/jupyter-teach.md
@@ -5,9 +5,9 @@ computing resources on the Teach Cluster. Through this webportal, students can r
 
 ## Step 1. Connecting to JupyterHub 
 
-Point your browser to the address below and authenticate using your Pitt credentials. The username needs to be all lowercase and is the
-same one used to access my.pitt.edu. The web host should be accessible for all users while connected through Wireless-PittNet. If that is 
-not the case, please try again while on [VPN](https://services.pitt.edu/TDClient/33/Portal/KB/ArticleDet?ID=293).
+Point your browser to the address below and authenticate using your Pitt credentials. The username needs to be all 
+lowercase and is the same one used to access my.pitt.edu. The web host should be accessible for all users while 
+connected through Wireless-PittNet. If that is not the case, please try again while on [VPN](https://services.pitt.edu/TDClient/33/Portal/KB/ArticleDet?ID=293).
 
 * **web hostname:** [https://jupyter.crc.pitt.edu](https://jupyter.crc.pitt.edu)
 * **authentication credentials:** Pitt username (all lowercase) and password

--- a/docs/snippets/ondemand-rstudio-gpu.md
+++ b/docs/snippets/ondemand-rstudio-gpu.md
@@ -5,9 +5,9 @@ dedicated GPUs. Through this webportal, researchers can leverage GPU compute nod
 
 ## Step 1. Connecting to Open OnDemand
 
-Point your browser to the address below and authenticate using your Pitt credentials. The username needs to be all lowercase and is the
-same one used to access my.pitt.edu. The web host should be accessible for all users while connected through Wireless-PittNet. If that is 
-not the case, please try again while on [VPN](https://services.pitt.edu/TDClient/33/Portal/KB/ArticleDet?ID=293).
+Point your browser to the address below and authenticate using your Pitt credentials. The username needs to be all 
+lowercase and is the same one used to access my.pitt.edu. The web host should be accessible for all users while 
+connected through Wireless-PittNet. If that is not the case, please try again while on [VPN](https://services.pitt.edu/TDClient/33/Portal/KB/ArticleDet?ID=293).
 
 * **web hostname:** [https://ondemand.htc.crc.pitt.edu](https://ondemand.htc.crc.pitt.edu)
 * **authentication credentials:** Pitt username (all lowercase) and password

--- a/docs/snippets/open-ondemand.md
+++ b/docs/snippets/open-ondemand.md
@@ -21,9 +21,8 @@ OSC (including many video tutorials) or submit a [help ticket](https://crc.pitt.
 
 If your computer is not connected to the Pitt network (e.g. you are working from remotely, or you are using Pitt 
 wireless network), or you are working from a laptop that is connected to the UPMC network, make sure you first 
-connect to the [Pitt VPN](https://www.technology.pitt.edu/services/pittnet-vpn-globalprotect), so that you can 
-communicate with the CRC resources. Note that there are many different VPN roles. 
-**Only Firewall-SAM-USERS-Pulse role** can connect to CRC clusters.
+connect to the [Pitt VPN](https://www.technology.pitt.edu/services/pittnet-vpn-globalprotect), so that you can communicate with the CRC resources. Note that there are many 
+different VPN roles. **Only Firewall-SAM-USERS-Pulse role** can connect to CRC clusters.
 
 After ensuring a VPN connection, navigate to [https://ondemand.htc.crc.pitt.edu](https://ondemand.htc.crc.pitt.edu) 
 in your web browser.

--- a/docs/snippets/psych.md
+++ b/docs/snippets/psych.md
@@ -8,7 +8,8 @@ The Psychiatry Web Portal is the gateway to CRCD compute and storage resources f
 
 To access this portal, you need to have a [user account](https://crc.pitt.edu/getting-started#) within CRCD and be a member of the \`psych\` group.
 
-The portal server is firewalled within PittNet and as such [you will need to be on VPN](https://crc.pitt.edu/user-support/resource-documentation/vpn-and-accessing-clusters) or be directly connected to PittNet via Ethernet.
+The portal server is firewalled within PittNet and as such [you will need to be on VPN](https://crc.pitt.edu/user-support/resource-documentation/vpn-and-accessing-clusters) or be directly connected 
+to PittNet via Ethernet.
 
 Once connected, you can run commands directly on the server and submit batch jobs to the CRCD clusters.
 

--- a/docs/snippets/terminal.md
+++ b/docs/snippets/terminal.md
@@ -3,6 +3,10 @@
 SSH ([**Secure Shell**](https://en.wikipedia.org/wiki/Secure_Shell)) is a network protocol that allows for secure access 
 to a computer over an unsecured network. This is the protocol for connecting to the CRCD login nodes.
 
+As with any of the other methods for connecting to CRCD resources, you should start by ensuring you have a proper 
+connection to the [GlobalProtect VPN](https://services.pitt.edu/TDClient/33/Portal/KB/ArticleDet?ID=293). With this 
+connection established, you can proceed with the steps below.
+
 Clients running Windows can use [**MobaXterm**](https://mobaxterm.mobatek.net/) or [**PuTTY**](https://www.putty.org/) to 
 access a terminal emulator. Clients running MacOS can use the built-in Terminal app (in Applications/Utilities) or 
 [**iTerm2**](https://iterm2.com/).

--- a/docs/snippets/viz.md
+++ b/docs/snippets/viz.md
@@ -2,23 +2,25 @@
 
 ## **Summary**
 
-VIZ is a set of nodes with a graphical user interface desktop enabled. In this document, we present all the information you need about VIZ.
+VIZ is a set of nodes with a graphical user interface desktop enabled. In this document, we present all the information
+you need about VIZ.
 
 [**Log in to VIZ**](https://viz.crc.pitt.edu)
 
-You can treat this machine as another login node with extra capability to access to GUI interface. You can also submit jobs to H2P or HTC using the VIZ interface.
-
-\[TOC Contents\]
+You can treat this machine as another login node with extra capability to access to GUI interface. You can also submit 
+jobs to H2P or HTC using the VIZ interface.
 
 ## **Access to VIZ**
 
 Like the other resources we have available, accessing VIZ requires a [connection to the PittNet VPN](https://crc.pitt.edu/user-support/resource-documentation/vpn-and-accessing-clusters).
 
-After connecting to the VPN, VIZ can be accessed either by the web portal, or by the fastx 2 desktop client. The benefit of using the desktop client is that copy/paste functionality works significantly better.
+After connecting to the VPN, VIZ can be accessed either by the web portal, or by the fastx 2 desktop client. The 
+benefit of using the desktop client is that copy/paste functionality works significantly better.
 
 ## **Desktop Client Method**
 
-[Download fastx 2 here](https://www.starnet.com/fastx/current-client?version=2.4.12) using the **Non-admin install build** link. If you have admin access on your device, you can install with the standard installer for all users.
+[Download fastx 2 here](https://www.starnet.com/fastx/current-client?version=2.4.12) using the **Non-admin install build** link. If you have admin access on your device, 
+you can install with the standard installer for all users.
 
 Install to a location accessible to you and run the FastX.exe file in the installation directory.
 
@@ -42,17 +44,19 @@ Double click the new connection in the Connections window, you will be prompted 
 
 The new window that opens is your Sessions window. This works similarly to the web portal interface.
 
-You can use the **plus icon** to create a new session, select your desktop interface (MATE is a good default), and click ok.
+You can use the **plus icon** to create a new session, select your desktop interface (MATE is a good default), and 
+click ok.
 
 ![](../_assets/img/web-portals/VizFastXDesktop_3.png)
 
-Your session will start and you can use this machine similarly to the login nodes for H2P and HTC.
+Your session will start, and you can use this machine similarly to the login nodes for H2P and HTC.
 
 ## **Web Portal Method**
 
 Below are some screenshots on how to access and use VIZ through the web portal.
 
-Open [this page](https://viz.crc.pitt.edu/) in a web browser and login with your Pitt username and password. Your username is your pittID, **making sure that all letters are lower case**.
+Open [this page](https://viz.crc.pitt.edu/) in a web browser and login with your Pitt username and password. Your username is your pittID, 
+**making sure that all letters are lower case**.
 
 ![](../_assets/img/web-portals/viz1.jpeg)
 
@@ -84,4 +88,5 @@ Open [this page](https://viz.crc.pitt.edu/) in a web browser and login with your
 
 Q: When I log in via the web portal, I am prompted for a second password. What do I put here?
 
-A: This is what happens when you enter your username (pitt ID) as all capitals instead of all lower case. You should re-attempt the connection using all lower case letters in your username.
+A: This is what happens when you enter your username (pitt ID) as all capitals instead of all lower case. You should 
+re-attempt the connection using all lower case letters in your username.

--- a/docs/web-portals/hugen.md
+++ b/docs/web-portals/hugen.md
@@ -2,7 +2,7 @@
 
 ## **Summary**
 
-The hugen.crc.pitt.edu or ondemand.teach.crc.pitt.edu Open Ondemand Web Portal is the gateway to CRC teach cluster to teach bioinformatics courses. Department of Human Genetics has paid part of the cost of this node. 
+The hugen.crc.pitt.edu or ondemand.teach.crc.pitt.edu Open Ondemand Web Portal is the gateway to CRCD teach cluster to teach bioinformatics courses. Department of Human Genetics has paid part of the cost of this node. 
 
 ## **Request an Allocation for a Course**
 
@@ -26,14 +26,14 @@ The portal server is firewalled within PittNet and as such [you will need to be 
 
 <p>If you are off-campus, the clusters are accessible securely from almost anywhere in the world via the PittNet Virtual Private Network&nbsp;(VPN), which is administered by Pitt IT. The VPN requires certain software to run on your system. We recommend Global Protect.</p>
 
-Once connected, you can run commands directly on the server and submit batch jobs to the CRC clusters. You can click >_ teach Shell Access under Clusters to get a Linux Shell Access.
+Once connected, you can run commands directly on the server and submit batch jobs to the CRCD clusters. You can click >_ teach Shell Access under Clusters to get a Linux Shell Access.
 
 ![](../_assets/img/web-portals/hugen1.png)
 ![](../_assets/img/web-portals/hugen2.png)
 
 We have not deployed a separate login node for the teach cluster. Thus, you will logon the login node of the HTC cluster.
 
-All CRC software can be accessed using this terminal and our LMOD software provisioning system.
+All CRCD software can be accessed using this terminal and our LMOD software provisioning system.
 
 <p><strong><a href="https://crc.pitt.edu/user-support/installed-software/cluster-application-environment">https://crc-pages.pitt.edu/user-manual/applications/application-environment/</a></strong></p>
 


### PR DESCRIPTION
This should close out #93. 

Includes some formatting changes to docs that already mentioned the VPN but had lines that were over 80 characters and were therefore difficult to read in my IDE.

